### PR TITLE
[Feat] 내 체험 등록, 수정 페이지 api 에러 처리, 주소 input 오류 해결, 자잘한 디자인 수정

### DIFF
--- a/src/apis/activitiesApi.ts
+++ b/src/apis/activitiesApi.ts
@@ -83,10 +83,31 @@ export const postActivitiesImageApi = async (image: FormData) => {
 export const postAddMyActivityApi = async (
   myActivity: AddMyActivityApiType,
 ) => {
-  const res = await axiosInstance.post(`activities`, myActivity, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  return res.data;
+  try {
+    const res = await axiosInstance.post(`activities`, myActivity, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return res;
+  } catch (e: any) {
+    if (e.response.status === 401) {
+      toast.error('로그인 해주세요.');
+    } else if (e.response.status === 400) {
+      toast.error('올바른 값을 입력해주세요.');
+    } else if (e.response.status === 409) {
+      toast.error('겹치는 예약 가능 시간대가 존재합니다.');
+    }
+  }
 };
+
+// export const postAddMyActivityApi = async (
+//   myActivity: AddMyActivityApiType,
+// ) => {
+//   const res = await axiosInstance.post(`activities`, myActivity, {
+//     headers: {
+//       'Content-Type': 'application/json',
+//     },
+//   });
+//   return res.data;
+// };

--- a/src/apis/activitiesApi.ts
+++ b/src/apis/activitiesApi.ts
@@ -91,12 +91,8 @@ export const postAddMyActivityApi = async (
     });
     return res;
   } catch (e: any) {
-    if (e.response.status === 401) {
-      toast.error('로그인 해주세요.');
-    } else if (e.response.status === 400) {
-      toast.error('올바른 값을 입력해주세요.');
-    } else if (e.response.status === 409) {
-      toast.error('겹치는 예약 가능 시간대가 존재합니다.');
+    if (e.response.status >= 400) {
+      toast.error(e.response.data.message);
     }
   }
 };

--- a/src/apis/myActivitiesApi.ts
+++ b/src/apis/myActivitiesApi.ts
@@ -14,13 +14,32 @@ export const patchEditMyActivityApi = async (
   id: number,
   editMyActivity: PatchEditMyActivityApiType,
 ) => {
-  const res = await axiosInstance.patch(`my-activities/${id}`, editMyActivity, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  return res.data;
+  try {
+    const res = await axiosInstance.patch(
+      `my-activities/${id}`,
+      editMyActivity,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    return res;
+  } catch (e: any) {
+    if (e.response.status === 401) {
+      toast.error('로그인 해주세요.');
+    } else if (e.response.status === 400) {
+      toast.error('올바른 값을 입력해주세요.');
+    } else if (e.response.status === 409) {
+      toast.error('겹치는 예약 가능 시간대가 존재합니다.');
+    } else if (e.response.status === 403) {
+      toast.error('본인의 체험만 수정할 수 있습니다.');
+    } else if (e.response.status === 404) {
+      toast.error('존재하지 않는 체험입니다.');
+    }
+  }
 };
+
 // 내 체험 삭제
 
 export const deleteActivitiesApi = async (id: number) => {

--- a/src/apis/myActivitiesApi.ts
+++ b/src/apis/myActivitiesApi.ts
@@ -26,16 +26,8 @@ export const patchEditMyActivityApi = async (
     );
     return res;
   } catch (e: any) {
-    if (e.response.status === 401) {
-      toast.error('로그인 해주세요.');
-    } else if (e.response.status === 400) {
-      toast.error('올바른 값을 입력해주세요.');
-    } else if (e.response.status === 409) {
-      toast.error('겹치는 예약 가능 시간대가 존재합니다.');
-    } else if (e.response.status === 403) {
-      toast.error('본인의 체험만 수정할 수 있습니다.');
-    } else if (e.response.status === 404) {
-      toast.error('존재하지 않는 체험입니다.');
+    if (e.response.status >= 400) {
+      toast.error(e.response.data.message);
     }
   }
 };

--- a/src/components/MyClass/MyClassInputs/AddressInput/AddressInput.tsx
+++ b/src/components/MyClass/MyClassInputs/AddressInput/AddressInput.tsx
@@ -1,4 +1,4 @@
-import { FieldErrors, UseFormRegister } from 'react-hook-form';
+import { FieldErrors, UseFormRegister, UseFormSetValue } from 'react-hook-form';
 import DaumPostcode from 'react-daum-postcode';
 import styles from './addressInput.module.scss';
 import { Dispatch, SetStateAction, useState } from 'react';
@@ -10,6 +10,7 @@ interface AddressInputProps {
   errors: FieldErrors<FormValues>;
   setGetAddress: Dispatch<SetStateAction<string>>;
   getAddress: string;
+  setValue: UseFormSetValue<FormValues>;
 }
 
 export default function AddressInput({
@@ -18,11 +19,13 @@ export default function AddressInput({
   errors,
   getAddress,
   setGetAddress,
+  setValue,
 }: AddressInputProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const onCompleteDaumPostcode = (data: { address: string }) => {
     setGetAddress(data.address);
+    setValue('address', data.address, { shouldDirty: true });
   };
 
   const toggleHandler = () => {
@@ -66,7 +69,11 @@ export default function AddressInput({
           />
         </div>
       )}
-      {errors ? <p className={styles.error}>{errors.address?.message}</p> : ''}
+      {errors && !getAddress ? (
+        <p className={styles.error}>{errors.address?.message}</p>
+      ) : (
+        ''
+      )}
     </div>
   );
 }

--- a/src/components/MyClass/MyClassInputs/DateInput/DateInput.tsx
+++ b/src/components/MyClass/MyClassInputs/DateInput/DateInput.tsx
@@ -37,7 +37,6 @@ export default function DateInput({
   fields,
   append,
   remove,
-  // plusDefaultValue,
 }: DateInputProps) {
   // const [dateInputArray, setDateInputArray] = useState<JSX.Element[]>([]);
 
@@ -80,8 +79,6 @@ export default function DateInput({
             className={`${styles.smallInput} ${styles.timeInput}`}
             id={id}
             type="time"
-            // value={defaultValue![0].startTime}
-
             {...register(`mainSchedule.startTime`, {
               required: '시작 시간 입력은 필수입니다.',
             })}
@@ -93,8 +90,6 @@ export default function DateInput({
             className={`${styles.smallInput} ${styles.timeInput}`}
             id={id}
             type="time"
-            // value={defaultValue![0].endTime}
-
             {...register(`mainSchedule.endTime`, {
               required: '종료 시간 입력은 필수입니다.',
             })}
@@ -134,66 +129,3 @@ export default function DateInput({
     </div>
   );
 }
-
-// return (
-//   <div>
-//     <label className={styles.inputTitle} htmlFor={id}>
-//       예약 가능한 시간대
-//     </label>
-//     <div className={styles.isAdd}>
-//       <div className={styles.smallInputWrapper}>
-//         <label className={styles.inputSubtitle}>날짜</label>
-//         <input
-//           className={`${styles.smallInput} ${styles.dateInput}`}
-//           id={id}
-//           type="date"
-//           {...register('schedules.  date', {
-//             required: '날짜 입력은 필수입니다.',
-//           })}
-//         />
-//       </div>
-//       <div className={styles.smallInputWrapper}>
-//         <label className={styles.inputSubtitle}>시작 시간</label>
-//         <input
-//           className={`${styles.smallInput} ${styles.timeInput}`}
-//           id={id}
-//           type="time"
-//           {...register('schedules.0.startTime', {
-//             required: '시작 시간 입력은 필수입니다.',
-//           })}
-//         />
-//       </div>
-//       <div className={styles.smallInputWrapper}>
-//         <label className={styles.inputSubtitle}>종료 시간</label>
-//         <input
-//           className={`${styles.smallInput} ${styles.timeInput}`}
-//           id={id}
-//           type="time"
-//           {...register('endTime', {
-//             required: '종료 시간 입력은 필수입니다.',
-//           })}
-//         />
-//       </div>
-//       <div>
-//         <Image
-//           className={styles.timePlusIcon}
-//           src="/assets/icons/plus-time-btn.svg"
-//           width={44}
-//           height={44}
-//           alt="시간 추가 버튼"
-//           onClick={addSelectTime}
-//         />
-//       </div>
-//     </div>
-//     {errors.date ? (
-//       <p className={styles.error}>{errors.date?.message}</p>
-//     ) : (
-//       ''
-//     )}
-//     {/* {dateInputArray ? dateInputArray : ''} */}
-//     {dateInputArray.map((element, index) => (
-//       <div key={index}>{element}</div>
-//     ))}
-//   </div>
-// );
-// }

--- a/src/components/MyClass/MyClassInputs/DateInput/DateInput.tsx
+++ b/src/components/MyClass/MyClassInputs/DateInput/DateInput.tsx
@@ -9,7 +9,6 @@ import styles from './dateInput.module.scss';
 import Image from 'next/image';
 import DateDeleteInput from './DatedeleteInput';
 import { FormValues } from '../../MyClassTitle/MyClassTitle';
-// import { useState } from 'react';
 
 interface DateInputProps {
   id: string;
@@ -113,21 +112,12 @@ export default function DateInput({
         </div>
       </div>
 
-      {errors.schedules ? (
-        <p className={styles.error}>{errors.schedules?.message}</p>
-      ) : (
-        ''
-      )}
-      {/* {dateInputArray ? dateInputArray : ''} */}
-      {/* {dateInputArray.map((element, index) => (
-        <div key={index}>{element}</div>
-      ))} */}
-
       <div className={styles.plusTimeBorder}>
         {fields.map((field, index) => {
           return (
             <div key={field.id}>
               <DateDeleteInput
+                errors={errors}
                 index={index}
                 register={register}
                 remove={remove}
@@ -136,6 +126,11 @@ export default function DateInput({
           );
         })}
       </div>
+      {(errors.mainSchedule?.date ||
+        errors.mainSchedule?.startTime ||
+        errors.mainSchedule?.endTime) && (
+        <p className={styles.error}>날짜 입력은 필수입니다.</p>
+      )}
     </div>
   );
 }

--- a/src/components/MyClass/MyClassInputs/DateInput/DatedeleteInput.tsx
+++ b/src/components/MyClass/MyClassInputs/DateInput/DatedeleteInput.tsx
@@ -2,11 +2,13 @@ import styles from './dateInput.module.scss';
 import deleteStyle from './dateDeleteInput.module.scss';
 import Image from 'next/image';
 import { FormValues } from '../../MyClassTitle/MyClassTitle';
-import { UseFieldArrayRemove, UseFormRegister } from 'react-hook-form';
+import {
+  FieldErrors,
+  UseFieldArrayRemove,
+  UseFormRegister,
+} from 'react-hook-form';
 
 interface DateDeleteInputProps {
-  // id: string;
-  // onClick: () => void;
   remove: UseFieldArrayRemove;
   index: number;
   register: UseFormRegister<FormValues>;
@@ -22,20 +24,21 @@ interface DateDeleteInputProps {
     startTime: string;
     endTime: string;
   };
+  errors: FieldErrors<FormValues>;
 }
 
 export default function DateDeleteInput({
-  // onClick,
   register,
   index,
   remove,
+  errors,
 }: DateDeleteInputProps) {
   const removeSelectTime = () => {
     remove(index);
   };
 
   return (
-    <div>
+    <>
       <div className={deleteStyle.smallInputContainer}>
         <div className={styles.smallInputWrapper}>
           <input
@@ -78,6 +81,17 @@ export default function DateDeleteInput({
           />
         </div>
       </div>
-    </div>
+      {/* {errors.schedules?.[index]?.date ||
+        errors.schedules?.[index]?.startTime ||
+        (errors.schedules?.[index]?.endTime && (
+          <p className={styles.error}>추가한 날짜 입력은 필수입니다.</p>
+        ))} */}
+
+      {(errors.schedules?.[index]?.date ||
+        errors.schedules?.[index]?.startTime ||
+        errors.schedules?.[index]?.endTime) && (
+        <p className={styles.error}>추가한 날짜 입력은 필수입니다.</p>
+      )}
+    </>
   );
 }

--- a/src/components/MyClass/MyClassInputs/DateInput/EditDateDeleteInput.tsx
+++ b/src/components/MyClass/MyClassInputs/DateInput/EditDateDeleteInput.tsx
@@ -2,7 +2,11 @@ import styles from './dateInput.module.scss';
 import deleteStyle from './dateDeleteInput.module.scss';
 import Image from 'next/image';
 import { FormValues } from '../../MyClassTitle/MyClassTitle';
-import { UseFieldArrayRemove, UseFormRegister } from 'react-hook-form';
+import {
+  FieldErrors,
+  UseFieldArrayRemove,
+  UseFormRegister,
+} from 'react-hook-form';
 import { Dispatch, SetStateAction } from 'react';
 
 interface DateDeleteInputProps {
@@ -34,6 +38,7 @@ interface DateDeleteInputProps {
     >
   >;
   deleteTime: (selectId: number) => void;
+  errors: FieldErrors<FormValues>;
 }
 
 export default function EditDateDeleteInput({
@@ -44,6 +49,7 @@ export default function EditDateDeleteInput({
   setGetPlusDateInfo,
   plusDefaultValue,
   deleteTime,
+  errors,
 }: DateDeleteInputProps) {
   const removeSelectTime = () => {
     remove(index);
@@ -52,7 +58,7 @@ export default function EditDateDeleteInput({
       // plusDefaultValue 배열에서 해당 item을 찾아서 필터링
       const newArr = plusDefaultValue.filter((value) => value.id !== item?.id);
       setGetPlusDateInfo(newArr);
-      console.log(newArr);
+      // console.log(newArr);
     }
     if (item) {
       deleteTime(item?.id);
@@ -60,52 +66,59 @@ export default function EditDateDeleteInput({
   };
 
   return (
-    <div>
-      <div className={deleteStyle.smallInputContainer}>
-        <div className={styles.smallInputWrapper}>
-          <input
-            className={`${deleteStyle.smallInput} ${deleteStyle.dateInput}`}
-            id="plusDate"
-            type="date"
-            value={item?.date}
-            {...register(`schedules.${index}.date`, {
-              required: '날짜 입력은 필수입니다.',
-            })}
-          />
-        </div>
-        <div className={styles.smallInputWrapper}>
-          <input
-            className={`${deleteStyle.smallInput} ${deleteStyle.timeInput}`}
-            id="plusStartTime"
-            type="time"
-            value={item?.startTime}
-            {...register(`schedules.${index}.startTime`, {
-              required: '시작 시간 입력은 필수입니다.',
-            })}
-          />
-        </div>
-        <div className={styles.smallInputWrapper}>
-          <input
-            className={`${deleteStyle.smallInput} ${deleteStyle.timeInput}`}
-            id="plusEndTime"
-            type="time"
-            value={item?.endTime}
-            {...register(`schedules.${index}.endTime`, {
-              required: '종료 시간 입력은 필수입니다.',
-            })}
-          />
-        </div>
-        <div>
-          <Image
-            className={styles.timePlusIcon}
-            src="/assets/icons/minus-time-btn.svg"
-            width={44}
-            height={44}
-            alt="시간 뺴기 버튼"
-            onClick={removeSelectTime}
-          />
+    <>
+      <div>
+        <div className={deleteStyle.smallInputContainer}>
+          <div className={styles.smallInputWrapper}>
+            <input
+              className={`${deleteStyle.smallInput} ${deleteStyle.dateInput}`}
+              id="plusDate"
+              type="date"
+              value={item?.date}
+              {...register(`schedules.${index}.date`, {
+                required: '날짜 입력은 필수입니다.',
+              })}
+            />
+          </div>
+          <div className={styles.smallInputWrapper}>
+            <input
+              className={`${deleteStyle.smallInput} ${deleteStyle.timeInput}`}
+              id="plusStartTime"
+              type="time"
+              value={item?.startTime}
+              {...register(`schedules.${index}.startTime`, {
+                required: '시작 시간 입력은 필수입니다.',
+              })}
+            />
+          </div>
+          <div className={styles.smallInputWrapper}>
+            <input
+              className={`${deleteStyle.smallInput} ${deleteStyle.timeInput}`}
+              id="plusEndTime"
+              type="time"
+              value={item?.endTime}
+              {...register(`schedules.${index}.endTime`, {
+                required: '종료 시간 입력은 필수입니다.',
+              })}
+            />
+          </div>
+          <div>
+            <Image
+              className={styles.timePlusIcon}
+              src="/assets/icons/minus-time-btn.svg"
+              width={44}
+              height={44}
+              alt="시간 뺴기 버튼"
+              onClick={removeSelectTime}
+            />
+          </div>
         </div>
       </div>
-    </div>
+      {(errors.schedules?.[index]?.date ||
+        errors.schedules?.[index]?.startTime ||
+        errors.schedules?.[index]?.endTime) && (
+        <p className={styles.error}>추가한 날짜 입력은 필수입니다.</p>
+      )}
+    </>
   );
 }

--- a/src/components/MyClass/MyClassInputs/DateInput/EditDateInput.tsx
+++ b/src/components/MyClass/MyClassInputs/DateInput/EditDateInput.tsx
@@ -114,12 +114,6 @@ export default function EditDateInput({
         </div>
       </div>
 
-      {errors.schedules ? (
-        <p className={styles.error}>{errors.schedules?.message}</p>
-      ) : (
-        ''
-      )}
-
       <div className={styles.plusTimeBorder}>
         {plusDefaultValue && !isAdd
           ? plusDefaultValue.map((item, index) => (
@@ -132,6 +126,7 @@ export default function EditDateInput({
                   deleteTime={deleteTime}
                   item={item}
                   plusDefaultValue={plusDefaultValue}
+                  errors={errors}
                 />
               </div>
             ))
@@ -148,6 +143,7 @@ export default function EditDateInput({
                   remove={remove}
                   setGetPlusDateInfo={setGetPlusDateInfo}
                   deleteTime={deleteTime}
+                  errors={errors}
                 />
               </div>
             );
@@ -155,6 +151,12 @@ export default function EditDateInput({
         </div>
       ) : (
         ''
+      )}
+
+      {(errors.mainSchedule?.date ||
+        errors.mainSchedule?.startTime ||
+        errors.mainSchedule?.endTime) && (
+        <p className={styles.error}>날짜 입력은 필수입니다.</p>
       )}
     </div>
   );

--- a/src/components/MyClass/MyClassInputs/DateInput/dateDeleteInput.module.scss
+++ b/src/components/MyClass/MyClassInputs/DateInput/dateDeleteInput.module.scss
@@ -3,7 +3,6 @@
 
 .smallInputContainer {
   @extend .smallInputContainer;
-  margin-top: 0px;
   margin-bottom: 8px;
   @media screen and (min-width: 375px) {
     margin-bottom: 16px;
@@ -15,7 +14,7 @@
 
 .smallInput {
   @extend .smallInput;
-  margin-top: 0px;
+  // margin-top: 0px;
 }
 
 .dateInput {

--- a/src/components/MyClass/MyClassInputs/DateInput/dateInput.module.scss
+++ b/src/components/MyClass/MyClassInputs/DateInput/dateInput.module.scss
@@ -83,13 +83,6 @@
   }
 }
 
-.error {
-  @extend .error;
-  padding-top: 0px;
-  padding-bottom: 15px;
-}
-
 .plusTimeBorder {
-  border-top: 1px solid $gray_DDDDDD;
-  padding-top: 16px;
+  // padding-top: 16px;
 }

--- a/src/components/MyClass/MyClassInputs/ImageInput/SubImgaeInput.tsx
+++ b/src/components/MyClass/MyClassInputs/ImageInput/SubImgaeInput.tsx
@@ -44,7 +44,6 @@ export default function SubImageInput({
       <label className={styles.inputTitle} htmlFor={id}>
         소개 이미지
       </label>
-      <div>{apiImgURL}</div>
       <div className={subImageStyle.imageContainer}>
         <div className={styles.addImgaeWapper} onChange={onChange}>
           <label className={styles.fakeInput} htmlFor="addSubImage">

--- a/src/components/MyClass/MyClassModal.tsx
+++ b/src/components/MyClass/MyClassModal.tsx
@@ -1,0 +1,22 @@
+import Button from '../Button/Button';
+import styles from './myClassModal.module.scss';
+
+interface MyClassModalProps {
+  message: string;
+  onClick: () => void;
+}
+
+export default function MyClassModal({ message, onClick }: MyClassModalProps) {
+  return (
+    <>
+      <div className={styles.modalBox}>
+        <div className={styles.messsageWrapper}>
+          <span className={styles.message}>{message}</span>
+        </div>
+        <div className={styles.button} onClick={onClick}>
+          <Button buttonTitle="확인" radius={4} fontSize={1.6} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/MyClass/MyClassTitle/EditMyClass.tsx
+++ b/src/components/MyClass/MyClassTitle/EditMyClass.tsx
@@ -14,6 +14,9 @@ import { DetailClassType } from '@/types/activitiesType/ActivitiesType';
 import { patchEditMyActivityApi } from '@/apis/myActivitiesApi';
 import EditSubImageInputContainer from '@/containers/ImageInput/EditSubImageInputContainer';
 import EditDateInput from '../MyClassInputs/DateInput/EditDateInput';
+import { useRouter } from 'next/router';
+import ModalBase from '@/components/Modal/ModalBase';
+import MyClassModal from '../MyClassModal';
 
 export interface FormValues {
   title: string;
@@ -40,6 +43,7 @@ interface MyClassTitleProps {
 }
 
 export default function EditMyClass({ buttonTitle }: MyClassTitleProps) {
+  const router = useRouter();
   const [deleteSubImageId, setDeleteSubImageId] = useState<number[]>([]);
   const [getActivityInfo, setGetActivityInfo] = useState<DetailClassType>();
   const [getPlusDateInfo, setGetPlusDateInfo] = useState<
@@ -123,6 +127,7 @@ export default function EditMyClass({ buttonTitle }: MyClassTitleProps) {
   //이미지 미리보기
   const [apiImgURL, setApiImgURL] = useState<string[]>([]);
   const [bannerApiImgURL, setBannerApiImgURL] = useState('');
+  const [isModalOpen, setIsModalOepn] = useState(false);
 
   const onSubmit = async (data: FormValues) => {
     // data.subImage = apiImgURL;
@@ -141,68 +146,96 @@ export default function EditMyClass({ buttonTitle }: MyClassTitleProps) {
       scheduleIdsToRemove: deleteDateId,
       schedulesToAdd: data.schedules,
     };
+
     const apiData = await patchEditMyActivityApi(id, editMyActivity);
-    console.log(apiData);
+    if (apiData) {
+      if (apiData.status === 200) {
+        setIsModalOepn(true);
+      }
+    }
   };
 
+  function closeModal() {
+    setIsModalOepn(false);
+    router.push('/my-page/my-class');
+  }
+
   return (
-    <div>
-      <form className={styles.myClassAddBox} onSubmit={handleSubmit(onSubmit)}>
-        <div className={styles.myClassTitleWrapper}>
-          <span className={styles.myClassSubtitle}>내 체험 등록</span>
-          <div className={styles.button}>
-            <Button buttonTitle={buttonTitle} radius={4} fontSize={1.6} />
+    <>
+      <div>
+        <form
+          className={styles.myClassAddBox}
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <div className={styles.myClassTitleWrapper}>
+            <span className={styles.myClassSubtitle}>내 체험 등록</span>
+            <div className={styles.button}>
+              <Button buttonTitle={buttonTitle} radius={4} fontSize={1.6} />
+            </div>
           </div>
-        </div>
-        <div className={styles.inputContainer}>
-          <TitleInput id="title" register={register} errors={errors} />
-          <CategoryInput id="category" register={register} errors={errors} />
-          <DescriptionInput
-            id="description"
-            register={register}
-            errors={errors}
-          />
-          <PriceInput id="price" register={register} errors={errors} />
-          <AddressInput
-            id="address"
-            register={register}
-            errors={errors}
-            getAddress={getAddress}
-            setGetAddress={setGetAddress}
-            setValue={setValue}
-          />
-          <EditDateInput
-            id="date"
-            register={register}
-            errors={errors}
-            fields={fields}
-            append={append}
-            remove={remove}
-            plusDefaultValue={getPlusDateInfo}
-            setGetPlusDateInfo={setGetPlusDateInfo}
-            setGonnaDeleteId={setGonnaDeleteId}
-          />
-          <ImageInputContainer
-            id="image"
-            register={register}
-            errors={errors}
-            apiImgURL={bannerApiImgURL}
-            setApiImgURL={setBannerApiImgURL}
-            setValue={setValue}
-          />
-          <EditSubImageInputContainer
-            id="subImage"
-            register={register}
-            errors={errors}
-            apiImgURL={apiImgURL}
-            setApiImgURL={setApiImgURL}
-            setIdWithApiImgURL={setIdWithApiImgURL}
-            idWithApiImgURL={idWithApiImgURL}
-            setDeleteSubImageId={setDeleteSubImageId}
-          />
-        </div>
-      </form>
-      <DevTool control={control} />
-    </div>
+          <div className={styles.inputContainer}>
+            <TitleInput id="title" register={register} errors={errors} />
+            <CategoryInput id="category" register={register} errors={errors} />
+            <DescriptionInput
+              id="description"
+              register={register}
+              errors={errors}
+            />
+            <PriceInput id="price" register={register} errors={errors} />
+            <AddressInput
+              id="address"
+              register={register}
+              errors={errors}
+              getAddress={getAddress}
+              setGetAddress={setGetAddress}
+              setValue={setValue}
+            />
+            <EditDateInput
+              id="date"
+              register={register}
+              errors={errors}
+              fields={fields}
+              append={append}
+              remove={remove}
+              plusDefaultValue={getPlusDateInfo}
+              setGetPlusDateInfo={setGetPlusDateInfo}
+              setGonnaDeleteId={setGonnaDeleteId}
+            />
+            <ImageInputContainer
+              id="image"
+              register={register}
+              errors={errors}
+              apiImgURL={bannerApiImgURL}
+              setApiImgURL={setBannerApiImgURL}
+              setValue={setValue}
+            />
+            <EditSubImageInputContainer
+              id="subImage"
+              register={register}
+              errors={errors}
+              apiImgURL={apiImgURL}
+              setApiImgURL={setApiImgURL}
+              setIdWithApiImgURL={setIdWithApiImgURL}
+              idWithApiImgURL={idWithApiImgURL}
+              setDeleteSubImageId={setDeleteSubImageId}
+            />
+          </div>
+        </form>
+        <DevTool control={control} />
+      </div>
+      {isModalOpen ? (
+        <ModalBase
+          children={
+            <MyClassModal
+              message="체험 수정이 완료되었습니다."
+              onClick={closeModal}
+            />
+          }
+          type="alert"
+        ></ModalBase>
+      ) : (
+        ''
+      )}
+    </>
   );
 }

--- a/src/components/MyClass/MyClassTitle/EditMyClass.tsx
+++ b/src/components/MyClass/MyClassTitle/EditMyClass.tsx
@@ -169,6 +169,7 @@ export default function EditMyClass({ buttonTitle }: MyClassTitleProps) {
             errors={errors}
             getAddress={getAddress}
             setGetAddress={setGetAddress}
+            setValue={setValue}
           />
           <EditDateInput
             id="date"

--- a/src/components/MyClass/MyClassTitle/MyClassTitle.tsx
+++ b/src/components/MyClass/MyClassTitle/MyClassTitle.tsx
@@ -13,6 +13,10 @@ import TitleInput from '../MyClassInputs/TitleInput/TitleInput';
 import { useState } from 'react';
 import { postAddMyActivityApi } from '@/apis/activitiesApi';
 
+import ModalBase from '@/components/Modal/ModalBase';
+import MyClassModal from '../MyClassModal';
+import { useRouter } from 'next/router';
+
 export interface FormValues {
   title: string;
   category: string;
@@ -38,6 +42,7 @@ interface MyClassTitleProps {
 }
 
 export default function MyClassTitle({ buttonTitle }: MyClassTitleProps) {
+  const router = useRouter();
   const [getAddress, setGetAddress] = useState('');
   const {
     control,
@@ -56,6 +61,8 @@ export default function MyClassTitle({ buttonTitle }: MyClassTitleProps) {
 
   const [apiImgURL, setApiImgURL] = useState<string[]>([]);
   const [bannerApiImgURL, setBannerApiImgURL] = useState('');
+  const [isModalOpen, setIsModalOepn] = useState(false);
+
   const onSubmit = async (data: FormValues) => {
     const dateArray = [data.mainSchedule];
     const combinedDateArray = dateArray.concat(data.schedules);
@@ -72,61 +79,88 @@ export default function MyClassTitle({ buttonTitle }: MyClassTitleProps) {
       subImageUrls: data.subImage,
     };
     const apiData = await postAddMyActivityApi(sendData);
-    console.log(apiData);
+    if (apiData) {
+      if (apiData.status === 201) {
+        setIsModalOepn(true);
+      }
+    }
   };
 
+  function closeModal() {
+    setIsModalOepn(false);
+    router.push('/my-page/my-class');
+  }
+
   return (
-    <div>
-      <form className={styles.myClassAddBox} onSubmit={handleSubmit(onSubmit)}>
-        <div className={styles.myClassTitleWrapper}>
-          <span className={styles.myClassSubtitle}>내 체험 등록</span>
-          <div className={styles.button}>
-            <Button buttonTitle={buttonTitle} radius={4} fontSize={1.6} />
+    <>
+      <div>
+        <form
+          className={styles.myClassAddBox}
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <div className={styles.myClassTitleWrapper}>
+            <span className={styles.myClassSubtitle}>내 체험 등록</span>
+            <div className={styles.button}>
+              <Button buttonTitle={buttonTitle} radius={4} fontSize={1.6} />
+            </div>
           </div>
-        </div>
-        <div className={styles.inputContainer}>
-          <TitleInput id="title" register={register} errors={errors} />
-          <CategoryInput id="category" register={register} errors={errors} />
-          <DescriptionInput
-            id="description"
-            register={register}
-            errors={errors}
-          />
-          <PriceInput id="price" register={register} errors={errors} />
-          <AddressInput
-            id="address"
-            register={register}
-            errors={errors}
-            getAddress={getAddress}
-            setGetAddress={setGetAddress}
-          />
-          <DateInput
-            id="date"
-            register={register}
-            errors={errors}
-            fields={fields}
-            append={append}
-            remove={remove}
-          />
-          <ImageInputContainer
-            setValue={setValue}
-            id="image"
-            register={register}
-            errors={errors}
-            apiImgURL={bannerApiImgURL}
-            setApiImgURL={setBannerApiImgURL}
-          />
-          <SubImageInputContainer
-            id="subImage"
-            register={register}
-            errors={errors}
-            setValue={setValue}
-            apiImgURL={apiImgURL}
-            setApiImgURL={setApiImgURL}
-          />
-        </div>
-      </form>
-      <DevTool control={control} />
-    </div>
+          <div className={styles.inputContainer}>
+            <TitleInput id="title" register={register} errors={errors} />
+            <CategoryInput id="category" register={register} errors={errors} />
+            <DescriptionInput
+              id="description"
+              register={register}
+              errors={errors}
+            />
+            <PriceInput id="price" register={register} errors={errors} />
+            <AddressInput
+              id="address"
+              register={register}
+              errors={errors}
+              getAddress={getAddress}
+              setGetAddress={setGetAddress}
+            />
+            <DateInput
+              id="date"
+              register={register}
+              errors={errors}
+              fields={fields}
+              append={append}
+              remove={remove}
+            />
+            <ImageInputContainer
+              setValue={setValue}
+              id="image"
+              register={register}
+              errors={errors}
+              apiImgURL={bannerApiImgURL}
+              setApiImgURL={setBannerApiImgURL}
+            />
+            <SubImageInputContainer
+              id="subImage"
+              register={register}
+              errors={errors}
+              setValue={setValue}
+              apiImgURL={apiImgURL}
+              setApiImgURL={setApiImgURL}
+            />
+          </div>
+        </form>
+        <DevTool control={control} />
+      </div>
+      {isModalOpen ? (
+        <ModalBase
+          children={
+            <MyClassModal
+              message="체험 등록이 완료되었습니다."
+              onClick={closeModal}
+            />
+          }
+          type="alert"
+        ></ModalBase>
+      ) : (
+        ''
+      )}
+    </>
   );
 }

--- a/src/components/MyClass/MyClassTitle/MyClassTitle.tsx
+++ b/src/components/MyClass/MyClassTitle/MyClassTitle.tsx
@@ -44,6 +44,7 @@ interface MyClassTitleProps {
 export default function MyClassTitle({ buttonTitle }: MyClassTitleProps) {
   const router = useRouter();
   const [getAddress, setGetAddress] = useState('');
+
   const {
     control,
     register,
@@ -119,6 +120,7 @@ export default function MyClassTitle({ buttonTitle }: MyClassTitleProps) {
               errors={errors}
               getAddress={getAddress}
               setGetAddress={setGetAddress}
+              setValue={setValue}
             />
             <DateInput
               id="date"

--- a/src/components/MyClass/myClassModal.module.scss
+++ b/src/components/MyClass/myClassModal.module.scss
@@ -1,0 +1,25 @@
+@import 'src/styles/variables';
+
+.modalBox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.messsageWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 50px;
+}
+
+.message {
+  font-size: 1.8rem;
+  font-weight: 500;
+}
+
+.button {
+  height: 42px;
+  width: 138px;
+}

--- a/src/containers/ImageInput/SubImageInputContainer.tsx
+++ b/src/containers/ImageInput/SubImageInputContainer.tsx
@@ -50,8 +50,6 @@ export default function SubImageInputContainer({
 
   return (
     <>
-      <div>{apiImgURL}</div>
-      <div>{imgURL}</div>
       <SubImageInput
         id={id}
         register={register}

--- a/src/containers/MyClass/MyClassContainer.tsx
+++ b/src/containers/MyClass/MyClassContainer.tsx
@@ -1,9 +1,0 @@
-import EditMyClass from '@/components/MyClass/MyClassTitle/EditMyClass';
-
-export default function MyClassContainer() {
-  return (
-    <>
-      <EditMyClass buttonTitle="수정하기" />
-    </>
-  );
-}

--- a/src/pages/my-page/my-class/edit-class/index.tsx
+++ b/src/pages/my-page/my-class/edit-class/index.tsx
@@ -1,11 +1,10 @@
 import Layout from '@/components/Layout/Layout';
-
-import MyClassContainer from '@/containers/MyClass/MyClassContainer';
+import EditMyClass from '@/components/MyClass/MyClassTitle/EditMyClass';
 
 export default function EditClass() {
   return (
     <Layout>
-      <MyClassContainer />
+      <EditMyClass buttonTitle="수정하기" />
     </Layout>
   );
 }


### PR DESCRIPTION
> 타이틀 작성 예시 ex) [Feat] 로그인 기능 추가

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 내 체험 등록, 수정 페이지 디자인 수정했습니다
- [x] api 에러처리 완료했습니다
- [x] 주소input 오류 해결했습니다
- [x] 내 체험 등록, 수정 완료시 모달 띄우고 확인 누르면 my-page/my-class 페이지로 이동하게 했습니다
- [x] footer 문제는 율민님 PR이 머지되면 해결 됩니다

협업이 필요한 부분?
- [ ] class-info/{체험 아이디} 페이지(체험 상세 선택 페이지)에서 수정하기 버튼 클릭 시 체험 아이디 받아오기
- [ ] my-page/my-class 페이지(내 체험 관리 페이지)에서 각 체험의 케밥에서 수정하기를 눌렀을 때 해당 체험 id 받아오기 

구현이 좀 더 필요한 부분
- [ ] 예약 있는 시간대는 수정 불가 처리하기
- [ ] 서브 이미지 개수 제한하기
- [ ] 인원 선택시 -값 선택 안 되게 하기
- [ ] 내 체험 수정 시 배너 이미지가 없는 거로 설정 되서 배너 이미지를 꼭 바꿔야지만 되는 문제 수정 필요
- [ ] 내 체험 수정 시 예약 가능한 시간대를 꼭 다 수정해야하는 문제 (api 문제인지 헷갈립니다)

### 스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 토스트 font size가 좀 큰 거 같습니다
