### PR TITLE
[🐛 Fix:]쿼리연동문제& 라우터 수정

### DIFF
--- a/src/components/Alarm/Alarm.module.scss
+++ b/src/components/Alarm/Alarm.module.scss
@@ -128,10 +128,12 @@
 .end {
   height: 10px;
   width: 100%;
+  padding: 10px;
 }
 
 .infinite {
   gap: 8px;
   display: flex;
   flex-direction: column;
+  margin-bottom: 8px;
 }

--- a/src/components/Modal2/ReserveInfoModal/ReserveInfoModal.tsx
+++ b/src/components/Modal2/ReserveInfoModal/ReserveInfoModal.tsx
@@ -38,10 +38,10 @@ export default function ReserveInfoModal({
   const [option, setOption] = useState(0);
   const [status, setStatus] = useState('pending');
   const [id, setId] = useState(0);
-  const [count] = useState(info[option].count);
-  const [app] = useState(count.pending);
-  const [con] = useState(count.confirmed);
-  const [dec] = useState(count.declined);
+  const count = info[option].count;
+  const app = count.pending;
+  const con = count.confirmed;
+  const dec = count.declined;
 
   const activityId = useRecoilValue(idAtom);
   const scheduleId = info[option].scheduleId;

--- a/src/components/Modal2/ReserveInfoModal/ReserveInfoModal.tsx
+++ b/src/components/Modal2/ReserveInfoModal/ReserveInfoModal.tsx
@@ -1,7 +1,7 @@
 import getReservations from '@/apis/getReservationsApi';
 import patchReservationsUpdate from '@/apis/patchReservationsUpdateApi';
 import { idAtom } from '@/store/atoms/idState';
-import { QueryClient, useMutation, useQuery } from '@tanstack/react-query';
+import { useQueryClient, useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import styles from './reserveInfoModal.module.scss';
@@ -34,7 +34,7 @@ export default function ReserveInfoModal({
   info: ScheduleInfo[];
   date: string;
 }) {
-  const queryClient = new QueryClient();
+  const queryClient = useQueryClient();
   const [option, setOption] = useState(0);
   const [status, setStatus] = useState('pending');
   const [id, setId] = useState(0);
@@ -46,24 +46,14 @@ export default function ReserveInfoModal({
   const activityId = useRecoilValue(idAtom);
   const scheduleId = info[option].scheduleId;
 
-  const { data } = useQuery<ReservationData>({
-    queryKey: ['reservation', status, option, scheduleId],
-    queryFn: () => getReservations({ activityId, scheduleId, status }),
-  });
-
-  console.log(data);
-
   const { mutate } = useMutation({
     mutationFn: patchReservationsUpdate,
     onSuccess: (data) => {
       setId(data.id);
-      alert('승인 성공');
       console.log(data);
-      autodecline();
-      queryClient.invalidateQueries(
-        { queryKey: ['reservation'] },
-        count as any,
-      );
+      queryClient.invalidateQueries({
+        queryKey: ['schedule'],
+      });
     },
     onError: (error) => {
       alert('승인 실패');
@@ -74,9 +64,8 @@ export default function ReserveInfoModal({
   const { mutate: decline } = useMutation({
     mutationFn: patchReservationsUpdate,
     onSuccess: (data) => {
-      alert('거절 성공');
       console.log(data);
-      queryClient.invalidateQueries({ queryKey: ['reservation'] });
+      queryClient.invalidateQueries({ queryKey: ['schedule'] });
     },
     onError: (error) => {
       alert('거절 실패');
@@ -100,6 +89,11 @@ export default function ReserveInfoModal({
       });
     });
   };
+
+  const { data } = useQuery<ReservationData>({
+    queryKey: ['reservation', status, option, scheduleId],
+    queryFn: () => getReservations({ activityId, scheduleId, status }),
+  });
 
   return (
     <>

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -74,7 +74,7 @@ export default function SideBar() {
       </form>
       <div id={styles.linkList}>
         <Link
-          href="/my-page/profile-info"
+          href="/my-page"
           className={`${styles.list} ${router.pathname === '/my-page/profile-info' ? styles.active : ''}`}
         >
           <Image

--- a/src/containers/AlarmContainer/AlarmContainer.tsx
+++ b/src/containers/AlarmContainer/AlarmContainer.tsx
@@ -1,5 +1,4 @@
 import Alarm from '@/components/Alarm/Alarm';
-import styles from './alarmContainer.module.scss';
 
 interface Notification {
   totalCount: number;
@@ -25,8 +24,8 @@ export default function AlarmContainer({
   setTarget: any;
 }) {
   return (
-    <div className={styles.alarmBox}>
+    <>
       <Alarm data={data} onClick={onClick} setTarget={setTarget} />
-    </div>
+    </>
   );
 }

--- a/src/containers/CalendarContainer/CalendarContainer.tsx
+++ b/src/containers/CalendarContainer/CalendarContainer.tsx
@@ -30,9 +30,6 @@ export default function CalendarContainer() {
     queryKey: ['schedule', date, activityId],
     queryFn: () => getReservedSchedule({ activityId, date }),
   });
-  console.log(activityId);
-  console.log(date);
-
   console.log(scheduleData);
 
   function getDates({ activeStartDate }: OnArgs): void {

--- a/src/pages/my-page/my-class/index.tsx
+++ b/src/pages/my-page/my-class/index.tsx
@@ -108,7 +108,7 @@ export default function MyClass() {
   };
 
   const handleAddClass = async () => {
-    router.push('/my-page/my-class/edit-class');
+    router.push('/my-page/my-class/add-class');
   };
 
   console.log(list);


### PR DESCRIPTION
- mutate의  queryClient.invalidateQueries 로 쿼리키를 연동해서 화면을 재렌더링 하는 기능이 작동하지않아서
문제를 찾아보니 이코드와 같이 있는 alert창이 문제였습니다. alert가 실행되면 코드가 강제로 return되면서 종료되네요.

- 간단한 경로 오류 몇가지 수정했습니다.\
--------------------------
- 알람컴포넌트 무한스크롤 오류해결
 관찰되는태그에 padding 줘서 해결함.

-----------------------------
- useState 정리, 안쓰는파일정리
